### PR TITLE
Fix meter/centimeter conversion output in unit converter

### DIFF
--- a/static/js/tools/unitConverter.js
+++ b/static/js/tools/unitConverter.js
@@ -28,7 +28,9 @@ export async function init(){
   function fmtNum(v){
     if(typeof v !== 'number' || !isFinite(v)) return '--';
     const rounded = Math.round(v * 1e6) / 1e6;
-    return ('' + rounded).replace(/\.?0+$/, '');
+    const asString = '' + rounded;
+    if(!asString.includes('.')) return asString;
+    return asString.replace(/0+$/, '').replace(/\.$/, '');
   }
 
   const lenVal = c.querySelector('#lenVal');


### PR DESCRIPTION
### Motivation
- Integer length conversions (for example `1 m -> 100 cm`) were being displayed incorrectly because the numeric formatter stripped digits when there was no decimal point, breaking `m`/`cm` output.

### Description
- Adjusted `fmtNum` in `static/js/tools/unitConverter.js` to only trim trailing zeros when a decimal point is present and to preserve integer results by returning the stringified number when no decimal exists.

### Testing
- Ran syntax checks across frontend scripts with `for f in static/js/main.js static/js/clock.js static/js/tools/*.js; do node --check "$f" || exit 1; done` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6647a4a688322995e2dcf11acb59e)