### PR TITLE
Improve unit converter parsing, formatting, and output units

### DIFF
--- a/static/js/tools/unitConverter.js
+++ b/static/js/tools/unitConverter.js
@@ -25,10 +25,11 @@ export async function init(){
     </div>
   `;
 
+  const numberFormatter = new Intl.NumberFormat('zh-CN', { maximumFractionDigits: 6 });
   function fmtNum(v){
     if(typeof v !== 'number' || !isFinite(v)) return '--';
     const rounded = Math.round(v * 1e6) / 1e6;
-    return ('' + rounded).replace(/\.?0+$/, '');
+    return numberFormatter.format(rounded);
   }
 
   const lenVal = c.querySelector('#lenVal');
@@ -44,26 +45,31 @@ export async function init(){
   const lenConvertBtn = c.querySelector('#lenConvertBtn');
   const tpConvertBtn = c.querySelector('#tpConvertBtn');
 
-  lenConvertBtn.onclick = ()=>{
-    const v = parseFloat(lenVal.value || '0');
+  function convertLength(){
+    const v = Number.parseFloat((lenVal.value || '').trim());
+    if(!Number.isFinite(v)) {
+      lenOut.textContent = '结果：--';
+      return;
+    }
+
     const from = lenFrom.value;
     const to = lenTo.value;
-    let m = v;
-    if(from === 'cm') m = v / 100;
-    if(from === 'ft') m = v * 0.3048;
-    let out = m;
-    if(to === 'cm') out = m * 100;
-    if(to === 'ft') out = m / 0.3048;
+    const unitToMeter = { m: 1, cm: 0.01, ft: 0.3048 };
+    const meterToUnit = { m: 1, cm: 100, ft: 1 / 0.3048 };
 
-    if(typeof out === 'number' && isFinite(out)) {
-      lenOut.textContent = '结果：' + fmtNum(out);
-    } else {
-      lenOut.textContent = '结果：--';
-    }
-  };
+    const meters = v * (unitToMeter[from] ?? 1);
+    const out = meters * (meterToUnit[to] ?? 1);
+
+    lenOut.textContent = Number.isFinite(out) ? `结果：${fmtNum(out)} ${to}` : '结果：--';
+  }
 
   function convertTemp(){
-    const v = parseFloat(tpVal.value || '0');
+    const v = Number.parseFloat((tpVal.value || '').trim());
+    if(!Number.isFinite(v)) {
+      tpOut.textContent = '结果：--';
+      return;
+    }
+
     const from = tpFrom.value;
     const to = tpTo.value;
     let cval = v;
@@ -71,7 +77,7 @@ export async function init(){
     let out = cval;
     if(to === 'F') out = cval * 9/5 + 32;
     if(typeof out === 'number' && isFinite(out)) {
-      tpOut.textContent = '结果：' + fmtNum(out);
+      tpOut.textContent = `结果：${fmtNum(out)} ${to === 'C' ? '℃' : '℉'}`;
     } else {
       tpOut.textContent = '结果：--';
     }
@@ -80,6 +86,7 @@ export async function init(){
   lenVal.addEventListener('keydown', (e)=>{ if(e.key === 'Enter') lenConvertBtn.click(); });
   tpVal.addEventListener('keydown', (e)=>{ if(e.key === 'Enter') tpConvertBtn.click(); });
 
+  lenConvertBtn.addEventListener('click', convertLength);
   tpConvertBtn.addEventListener('click', convertTemp);
 
   return c;


### PR DESCRIPTION
### Motivation

- Improve numeric formatting and localization to avoid long decimals and trim trailing zeros.
- Make input parsing more robust and treat empty/invalid input as no-result instead of defaulting to 0.
- Clean up conversion logic for length units and make outputs clearer by showing unit labels.

### Description

- Add an `Intl.NumberFormat('zh-CN', { maximumFractionDigits: 6 })` formatter and use it in `fmtNum` to localize and limit fractional digits.
- Replace manual rounding and regex trimming with the new number formatter in `fmtNum`.
- Use `Number.parseFloat((... ).trim())` and `Number.isFinite` for `tpVal` and `lenVal` parsing to handle whitespace and invalid input, returning `结果：--` for non-finite values.
- Extract length conversion into a new `convertLength` function, replace ad-hoc conversions with `unitToMeter`/`meterToUnit` maps, append unit labels to outputs, and switch the length button handler to `addEventListener('click', convertLength)`.

### Testing

- Ran the project's linter via `npm run lint`, which succeeded; no automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6647a4a688322995e2dcf11acb59e)