### PR TITLE
Add daily-quote API + widget; revamp calculator UI and styles with caching & rate limiting

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,115 @@
-from flask import Flask, render_template
+import json
+import os
+import threading
+import time
+from collections import defaultdict, deque
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from urllib.error import URLError, HTTPError
+from urllib.request import Request, urlopen
+
+from flask import Flask, jsonify, render_template, request
 
 app = Flask(__name__, static_folder="static", template_folder="templates")
+
+DAILY_QUOTE_FALLBACK = "你瞅啥"
+QUOTE_CACHE = {
+    "date": None,
+    "quote": DAILY_QUOTE_FALLBACK,
+}
+QUOTE_LOCK = threading.Lock()
+
+RATE_LIMIT_WINDOW = 60
+RATE_LIMIT_MAX = 30
+RATE_LIMITER = defaultdict(deque)
+RATE_LIMIT_LOCK = threading.Lock()
+
 
 @app.route("/")
 def index():
     return render_template("index.html")
+
+
+def _today_str() -> str:
+    now = datetime.now(ZoneInfo("Asia/Shanghai"))
+    return now.strftime("%Y-%m-%d")
+
+
+def _extract_quote(response_data: dict) -> str:
+    choices = response_data.get("choices") or []
+    if not choices:
+        return DAILY_QUOTE_FALLBACK
+    message = (choices[0] or {}).get("message") or {}
+    content = (message.get("content") or "").strip()
+    return content or DAILY_QUOTE_FALLBACK
+
+
+def _call_quote_api(today: str) -> str:
+    api_key = os.environ.get("DAILY_QUOTE_API_KEY", "")
+    api_url = os.environ.get("DAILY_QUOTE_API_URL", "")
+    model_name = os.environ.get("DAILY_QUOTE_MODEL", "")
+
+    if not api_key or not api_url or not model_name:
+        return DAILY_QUOTE_FALLBACK
+
+    payload = {
+        "model": model_name,
+        "messages": [
+            {"role": "system", "content": "你是一个名言生成助手。"},
+            {
+                "role": "user",
+                "content": f"请给出{today}的每日名言，只返回一句中文名言，不要带序号和解释。",
+            },
+        ],
+        "temperature": 0.8,
+    }
+
+    req = Request(
+        api_url,
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+
+    try:
+        with urlopen(req, timeout=8) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            return _extract_quote(data)
+    except (URLError, HTTPError, TimeoutError, json.JSONDecodeError):
+        return DAILY_QUOTE_FALLBACK
+
+
+def _check_rate_limit(client_ip: str) -> bool:
+    now = time.time()
+    with RATE_LIMIT_LOCK:
+        q = RATE_LIMITER[client_ip]
+        while q and now - q[0] > RATE_LIMIT_WINDOW:
+            q.popleft()
+        if len(q) >= RATE_LIMIT_MAX:
+            return False
+        q.append(now)
+        return True
+
+
+@app.route("/api/daily-quote", methods=["GET"])
+def daily_quote():
+    client_ip = request.headers.get("X-Forwarded-For", request.remote_addr or "unknown").split(",")[0].strip()
+    if not _check_rate_limit(client_ip):
+        return jsonify({"quote": DAILY_QUOTE_FALLBACK, "date": _today_str(), "error": "rate_limited"}), 429
+
+    today = _today_str()
+    with QUOTE_LOCK:
+        if QUOTE_CACHE["date"] != today:
+            QUOTE_CACHE["quote"] = _call_quote_api(today)
+            QUOTE_CACHE["date"] = today
+
+        quote = QUOTE_CACHE["quote"] or DAILY_QUOTE_FALLBACK
+
+    return jsonify({"quote": quote, "date": today})
+
 
 if __name__ == "__main__":
     app.run(debug=False, host="0.0.0.0", port=5000)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -127,3 +127,76 @@ html, body {
   .toolButtons button{flex:1 1 45%}
   .toolArea{min-height:140px}
 }
+
+.calc-widget {
+  width: min(360px, 96%);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.calc-screen-wrap {
+  width: 100%;
+}
+
+.calc-screen {
+  width: 100%;
+  font-size: 22px;
+  text-align: right;
+  padding: 10px;
+  border-radius: 10px;
+}
+
+.calc-out {
+  margin-top: 6px;
+  text-align: right;
+  color: var(--muted);
+  min-height: 20px;
+}
+
+.calc-pad {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  width: 100%;
+}
+
+.calc-key {
+  width: 100%;
+  min-height: 44px;
+  font-size: 18px;
+  border-radius: 10px;
+}
+
+.calc-key-op { color: #9ee6ff; }
+.calc-key-fn { color: #ffdca7; }
+.calc-key-eq {
+  background: linear-gradient(90deg, rgba(102,217,255,0.35), rgba(170,230,255,0.12));
+}
+
+.quote-widget {
+  width: min(520px, 96%);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.quote-title {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.quote-text {
+  font-size: 18px;
+  line-height: 1.7;
+  padding: 10px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255,255,255,0.06);
+}
+
+.quote-meta {
+  font-size: 13px;
+  color: var(--muted);
+}

--- a/static/js/tools/calculator.js
+++ b/static/js/tools/calculator.js
@@ -115,13 +115,40 @@ function safeEvaluate(expr){
 
 export async function init(){
   const container = document.createElement('div');
+  container.className = 'calc-widget';
   container.innerHTML = `
-    <div style="display:flex;gap:8px;align-items:center">
-      <input id="calcExpr" placeholder="例如 12/3 + 4" style="flex:1;padding:6px;border-radius:6px"/>
-      <button id="calcGo">计算</button>
+    <div class="calc-screen-wrap">
+      <input id="calcExpr" class="calc-screen" placeholder="0" aria-label="计算表达式" readonly />
+      <div id="calcOut" class="calc-out">点击数字和运算符开始计算</div>
     </div>
-    <div id="calcOut" style="margin-top:8px;color:var(--muted)"></div>
+    <div class="calc-pad" role="group" aria-label="计算器按键">
+      <button class="calc-key calc-key-fn" data-val="clear">C</button>
+      <button class="calc-key calc-key-fn" data-val="(">(</button>
+      <button class="calc-key calc-key-fn" data-val=")">)</button>
+      <button class="calc-key calc-key-op" data-val="/">÷</button>
+
+      <button class="calc-key" data-val="7">7</button>
+      <button class="calc-key" data-val="8">8</button>
+      <button class="calc-key" data-val="9">9</button>
+      <button class="calc-key calc-key-op" data-val="*">×</button>
+
+      <button class="calc-key" data-val="4">4</button>
+      <button class="calc-key" data-val="5">5</button>
+      <button class="calc-key" data-val="6">6</button>
+      <button class="calc-key calc-key-op" data-val="-">-</button>
+
+      <button class="calc-key" data-val="1">1</button>
+      <button class="calc-key" data-val="2">2</button>
+      <button class="calc-key" data-val="3">3</button>
+      <button class="calc-key calc-key-op" data-val="+">+</button>
+
+      <button class="calc-key calc-key-fn" data-val="back">⌫</button>
+      <button class="calc-key" data-val="0">0</button>
+      <button class="calc-key" data-val=".">.</button>
+      <button class="calc-key calc-key-eq" data-val="=">=</button>
+    </div>
   `;
+
   const expr = container.querySelector('#calcExpr');
   const out = container.querySelector('#calcOut');
 
@@ -134,7 +161,27 @@ export async function init(){
     }
   }
 
-  container.querySelector('#calcGo').addEventListener('click', run);
-  expr.addEventListener('keydown', (e)=>{ if(e.key === 'Enter') run(); });
+  container.querySelectorAll('.calc-key').forEach((btn)=>{
+    btn.addEventListener('click', ()=>{
+      const val = btn.dataset.val;
+      if(val === 'clear'){
+        expr.value = '';
+        out.textContent = '已清空';
+        return;
+      }
+      if(val === 'back'){
+        expr.value = expr.value.slice(0, -1);
+        out.textContent = expr.value ? '继续输入' : '已清空';
+        return;
+      }
+      if(val === '='){
+        run();
+        return;
+      }
+      expr.value += val;
+      out.textContent = '继续输入';
+    });
+  });
+
   return container;
 }

--- a/static/js/tools/dailyQuote.js
+++ b/static/js/tools/dailyQuote.js
@@ -1,0 +1,32 @@
+export async function init(){
+  const el = document.createElement('div');
+  el.className = 'quote-widget';
+  el.innerHTML = `
+    <div class="quote-title">每日名言</div>
+    <div id="quoteText" class="quote-text">加载中...</div>
+    <div id="quoteMeta" class="quote-meta"></div>
+    <button id="quoteRefresh" class="quote-refresh">手动刷新</button>
+  `;
+
+  const textEl = el.querySelector('#quoteText');
+  const metaEl = el.querySelector('#quoteMeta');
+
+  async function loadQuote(){
+    textEl.textContent = '加载中...';
+    metaEl.textContent = '';
+    try {
+      const resp = await fetch('/api/daily-quote', { method: 'GET' });
+      if(!resp.ok) throw new Error(`http-${resp.status}`);
+      const data = await resp.json();
+      textEl.textContent = data.quote || '你瞅啥';
+      metaEl.textContent = data.date ? `日期：${data.date}` : '';
+    } catch {
+      textEl.textContent = '你瞅啥';
+      metaEl.textContent = '已启用兜底文案';
+    }
+  }
+
+  el.querySelector('#quoteRefresh').addEventListener('click', loadQuote);
+  await loadQuote();
+  return el;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -90,6 +90,7 @@
           <button data-tool="worldClocks" class="neon-btn">世界时钟</button>
           <button data-tool="calendar" class="neon-btn">日历</button>
           <button data-tool="passwordGen" class="neon-btn">随机密码</button>
+          <button data-tool="dailyQuote" class="neon-btn">每日名言</button>
         </div>
         <div id="toolArea" class="toolArea">
           <div class="hint">点击上方按钮加载对应小工具</div>


### PR DESCRIPTION
### Motivation
- Provide a daily quote feature served from the backend and display it as a client widget with a safe fallback when the upstream fails. 
- Improve the on-page calculator to a touch-friendly, accessible keypad UI and consolidate styling for new widgets. 
- Prevent abuse of the daily-quote endpoint and avoid repeated upstream calls by adding simple rate limiting and per-day caching.

### Description
- Added a new `/api/daily-quote` GET endpoint in `app.py` that returns JSON with `quote` and `date`, implements per-day caching (`QUOTE_CACHE`) and a token-like rate limiter (`RATE_LIMITER`, `RATE_LIMIT_WINDOW`, `RATE_LIMIT_MAX`) keyed by client IP, and calls an external quote API using env vars `DAILY_QUOTE_API_KEY`, `DAILY_QUOTE_API_URL`, and `DAILY_QUOTE_MODEL` with a timezone-aware date from `ZoneInfo("Asia/Shanghai")`; a Chinese fallback string `DAILY_QUOTE_FALLBACK` is used on errors. 
- Added `static/js/tools/dailyQuote.js` to fetch and render the daily quote widget with a manual refresh button and graceful fallback messaging. 
- Reworked `static/js/tools/calculator.js` to replace a single-line input and button with a full keypad UI, keyboard-free interactions, clearer state messages, and ARIA attributes; container now uses `calc-widget` class. 
- Expanded `static/css/style.css` with styles for `calc-*` classes and `quote-*` classes to support the new calculator and quote widget layouts and visuals. 
- Updated `templates/index.html` to add a `每日名言` tool button that loads the new widget.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a854a317148332811933846c0dba4a)