### PR TITLE
Fix calculator button styles and stabilize daily quote fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ DAILY_QUOTE_FALLBACK = "你瞅啥"
 QUOTE_CACHE = {
     "date": None,
     "quote": DAILY_QUOTE_FALLBACK,
+    "is_fallback": True,
 }
 QUOTE_LOCK = threading.Lock()
 
@@ -44,13 +45,13 @@ def _extract_quote(response_data: dict) -> str:
     return content or DAILY_QUOTE_FALLBACK
 
 
-def _call_quote_api(today: str) -> str:
+def _call_quote_api(today: str) -> tuple[str, bool]:
     api_key = os.environ.get("DAILY_QUOTE_API_KEY", "")
     api_url = os.environ.get("DAILY_QUOTE_API_URL", "")
     model_name = os.environ.get("DAILY_QUOTE_MODEL", "")
 
     if not api_key or not api_url or not model_name:
-        return DAILY_QUOTE_FALLBACK
+        return DAILY_QUOTE_FALLBACK, True
 
     payload = {
         "model": model_name,
@@ -77,9 +78,10 @@ def _call_quote_api(today: str) -> str:
     try:
         with urlopen(req, timeout=8) as resp:
             data = json.loads(resp.read().decode("utf-8"))
-            return _extract_quote(data)
+            quote = _extract_quote(data)
+            return quote, quote == DAILY_QUOTE_FALLBACK
     except (URLError, HTTPError, TimeoutError, json.JSONDecodeError):
-        return DAILY_QUOTE_FALLBACK
+        return DAILY_QUOTE_FALLBACK, True
 
 
 def _check_rate_limit(client_ip: str) -> bool:
@@ -103,12 +105,15 @@ def daily_quote():
     today = _today_str()
     with QUOTE_LOCK:
         if QUOTE_CACHE["date"] != today:
-            QUOTE_CACHE["quote"] = _call_quote_api(today)
+            quote, is_fallback = _call_quote_api(today)
+            QUOTE_CACHE["quote"] = quote
+            QUOTE_CACHE["is_fallback"] = is_fallback
             QUOTE_CACHE["date"] = today
 
         quote = QUOTE_CACHE["quote"] or DAILY_QUOTE_FALLBACK
+        is_fallback = QUOTE_CACHE["is_fallback"]
 
-    return jsonify({"quote": quote, "date": today})
+    return jsonify({"quote": quote, "date": today, "isFallback": is_fallback})
 
 
 if __name__ == "__main__":

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -174,6 +174,21 @@ html, body {
   background: linear-gradient(90deg, rgba(102,217,255,0.35), rgba(170,230,255,0.12));
 }
 
+
+.toolArea .calc-key {
+  background: linear-gradient(135deg, rgba(255,255,255,0.03), rgba(255,255,255,0.02));
+  border: none;
+  box-shadow: var(--btn-glow);
+}
+
+.toolArea .calc-key:hover {
+  box-shadow: var(--btn-glow-strong);
+  background: linear-gradient(135deg, rgba(102,217,255,0.06), rgba(255,255,255,0.02));
+}
+
+.toolArea .calc-key-eq {
+  background: linear-gradient(90deg, rgba(102,217,255,0.35), rgba(170,230,255,0.12));
+}
 .quote-widget {
   width: min(520px, 96%);
   text-align: center;

--- a/static/js/tools/dailyQuote.js
+++ b/static/js/tools/dailyQuote.js
@@ -14,15 +14,23 @@ export async function init(){
   async function loadQuote(){
     textEl.textContent = '加载中...';
     metaEl.textContent = '';
+    const controller = new AbortController();
+    const timer = setTimeout(()=> controller.abort(), 5000);
     try {
-      const resp = await fetch('/api/daily-quote', { method: 'GET' });
+      const resp = await fetch('/api/daily-quote', { method: 'GET', signal: controller.signal });
       if(!resp.ok) throw new Error(`http-${resp.status}`);
       const data = await resp.json();
       textEl.textContent = data.quote || '你瞅啥';
-      metaEl.textContent = data.date ? `日期：${data.date}` : '';
+      if(data.isFallback){
+        metaEl.textContent = data.date ? `日期：${data.date}（已启用兜底文案）` : '已启用兜底文案';
+      }else{
+        metaEl.textContent = data.date ? `日期：${data.date}` : '';
+      }
     } catch {
       textEl.textContent = '你瞅啥';
       metaEl.textContent = '已启用兜底文案';
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/tests/test_daily_quote.py
+++ b/tests/test_daily_quote.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+from unittest.mock import patch
+
+import app as board_app
+
+
+class DailyQuoteTests(unittest.TestCase):
+    def setUp(self):
+        self.client = board_app.app.test_client()
+        board_app.QUOTE_CACHE["date"] = None
+        board_app.QUOTE_CACHE["quote"] = board_app.DAILY_QUOTE_FALLBACK
+        board_app.QUOTE_CACHE["is_fallback"] = True
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_call_quote_api_returns_fallback_without_config(self):
+        quote, is_fallback = board_app._call_quote_api("2026-03-05")
+        self.assertEqual(quote, board_app.DAILY_QUOTE_FALLBACK)
+        self.assertTrue(is_fallback)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_api_response_marks_fallback_flag(self):
+        resp = self.client.get('/api/daily-quote')
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.get_json()
+        self.assertEqual(payload["quote"], board_app.DAILY_QUOTE_FALLBACK)
+        self.assertTrue(payload["isFallback"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- 计算器按键在工具区加载时被通用 `.toolArea button` 规则覆盖导致样式未生效，需要提升计算器按键的样式优先级以恢复预期视觉效果。 
- 每日名言小工具在无法拿到远端 API 或请求超时情况下没有明确兜底展示，需要前后端协同提供显式的兜底标识并在前端增加超时保护以提升稳定性。

### Description
- 在 `static/css/style.css` 中新增 `.toolArea .calc-key`、`.toolArea .calc-key:hover` 和 `.toolArea .calc-key-eq` 样式来覆盖通用按钮规则，恢复计算器按键的视觉样式。 
- 在 `static/js/tools/dailyQuote.js` 中为 `fetch` 增加 `AbortController` 超时（5 秒）并根据后端返回的 `isFallback` 字段在元信息处显示“已启用兜底文案”。
- 在 `app.py` 中将 `_call_quote_api` 改为返回 `(quote, is_fallback)`，在 `QUOTE_CACHE` 中记录 `is_fallback`，并在 `/api/daily-quote` 接口响应中新增 `isFallback` 字段以便前端判断。 
- 新增回归测试 `tests/test_daily_quote.py`，覆盖当未配置 API 环境变量时 `_call_quote_api` 返回兜底文案及接口返回 `isFallback` 为 `true` 的行为。

### Testing
- 运行单元测试 `python -m unittest discover -s tests -p 'test_*.py' -v`，2 个新增测试均通过（OK）。
- 启动本地服务器并用 `curl` 验证 `GET /api/daily-quote` 返回包含 `isFallback` 字段（示例：`{"date":"...","isFallback":true,"quote":"..."}`）。
- 使用浏览器自动化脚本（Playwright）手工验证工具栏中切换加载 `calculator` 和 `dailyQuote` 并截取页面截图以确认 UI 与文案展示。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8dd72c4808322a989347d7faabdbe)