### PR TITLE
Fix calculator styling and daily-quote parsing/refresh

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,7 +41,14 @@ def _extract_quote(response_data: dict) -> str:
     if not choices:
         return DAILY_QUOTE_FALLBACK
     message = (choices[0] or {}).get("message") or {}
-    content = (message.get("content") or "").strip()
+    content = message.get("content") or ""
+    if isinstance(content, list):
+        text_parts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text_parts.append(item.get("text") or "")
+        content = "".join(text_parts)
+    content = str(content).strip()
     return content or DAILY_QUOTE_FALLBACK
 
 
@@ -104,7 +111,8 @@ def daily_quote():
 
     today = _today_str()
     with QUOTE_LOCK:
-        if QUOTE_CACHE["date"] != today:
+        should_refresh = QUOTE_CACHE["date"] != today or QUOTE_CACHE["is_fallback"]
+        if should_refresh:
             quote, is_fallback = _call_quote_api(today)
             QUOTE_CACHE["quote"] = quote
             QUOTE_CACHE["is_fallback"] = is_fallback

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -133,6 +133,10 @@ html, body {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(5, 13, 22, 0.55);
+  border: 1px solid rgba(160, 230, 255, 0.12);
 }
 
 .calc-screen-wrap {
@@ -145,6 +149,9 @@ html, body {
   text-align: right;
   padding: 10px;
   border-radius: 10px;
+  background: rgba(0, 0, 0, 0.36);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #eaf9ff;
 }
 
 .calc-out {
@@ -166,6 +173,7 @@ html, body {
   min-height: 44px;
   font-size: 18px;
   border-radius: 10px;
+  appearance: none;
 }
 
 .calc-key-op { color: #9ee6ff; }

--- a/static/js/tools/dailyQuote.js
+++ b/static/js/tools/dailyQuote.js
@@ -17,7 +17,11 @@ export async function init(){
     const controller = new AbortController();
     const timer = setTimeout(()=> controller.abort(), 5000);
     try {
-      const resp = await fetch('/api/daily-quote', { method: 'GET', signal: controller.signal });
+      const resp = await fetch('/api/daily-quote', {
+        method: 'GET',
+        signal: controller.signal,
+        cache: 'no-store',
+      });
       if(!resp.ok) throw new Error(`http-${resp.status}`);
       const data = await resp.json();
       textEl.textContent = data.quote || '你瞅啥';

--- a/tests/test_daily_quote.py
+++ b/tests/test_daily_quote.py
@@ -18,6 +18,29 @@ class DailyQuoteTests(unittest.TestCase):
         self.assertEqual(quote, board_app.DAILY_QUOTE_FALLBACK)
         self.assertTrue(is_fallback)
 
+
+    def test_extract_quote_supports_array_content(self):
+        payload = {
+            "choices": [
+                {"message": {"content": [{"type": "text", "text": "向光而行"}]}}
+            ]
+        }
+        quote = board_app._extract_quote(payload)
+        self.assertEqual(quote, "向光而行")
+
+    def test_refreshes_when_cache_is_fallback(self):
+        board_app.QUOTE_CACHE["date"] = board_app._today_str()
+        board_app.QUOTE_CACHE["quote"] = board_app.DAILY_QUOTE_FALLBACK
+        board_app.QUOTE_CACHE["is_fallback"] = True
+
+        with patch("app._call_quote_api", return_value=("今天会更好", False)) as mocked:
+            resp = self.client.get('/api/daily-quote')
+
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.get_json()
+        self.assertEqual(payload["quote"], "今天会更好")
+        self.assertFalse(payload["isFallback"])
+        mocked.assert_called_once()
     @patch.dict(os.environ, {}, clear=True)
     def test_api_response_marks_fallback_flag(self):
         resp = self.client.get('/api/daily-quote')


### PR DESCRIPTION
### Motivation

- Calculator numeric and operator buttons were rendered with default/plain controls and lacked the intended custom styling, making keys invisible or inconsistent in the UI.  
- Daily quote display could remain stuck on the fallback quote because backend parsing did not handle OpenAI-like `message.content` arrays and the cache kept fallback results for the whole day.

### Description

- Updated `app.py` to make `_extract_quote` robust to `message.content` being an array of typed blocks (e.g. `[{"type":"text","text":"..."}]`) and to properly trim and return fallback when empty.  
- Changed the daily-quote cache logic in `app.py` so the server will re-call the upstream API when the cache for today is a fallback (`is_fallback`) instead of pinning the fallback for the entire day.  
- Added `cache: 'no-store'` to the front-end fetch in `static/js/tools/dailyQuote.js` to avoid browser caching preventing visible refreshes.  
- Improved calculator UI rules in `static/css/style.css` to ensure the calculator container, screen and keys receive consistent custom styles (background, borders, text color, `appearance: none`, hover effects) so numeric and operator buttons are visibly rendered.  
- Added/updated unit tests in `tests/test_daily_quote.py` to cover array-form `content` parsing (`test_extract_quote_supports_array_content`) and the behavior where a fallback cache should trigger a refresh (`test_refreshes_when_cache_is_fallback`).

### Testing

- Ran unit tests with `python -m unittest discover -s tests -v` and all tests passed: `test_call_quote_api_returns_fallback_without_config`, `test_api_response_marks_fallback_flag`, `test_extract_quote_supports_array_content`, and `test_refreshes_when_cache_is_fallback` (4 tests, OK).  
- Started the Flask server (`python app.py`) and exercised the UI with a Playwright script to load the page, open the calculator and daily-quote tools, and captured screenshots verifying the calculator keys are styled and the daily quote is fetched/refreshed; screenshots were produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8e34ff6648322993606ba9880368a)