### PR TITLE
Support varied daily-quote responses, refresh fallback cache, improve calculator UI, and add tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,13 +36,51 @@ def _today_str() -> str:
     return now.strftime("%Y-%m-%d")
 
 
+def _stringify_content(content: object) -> str:
+    if isinstance(content, list):
+        text_parts = []
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text":
+                    text_parts.append(item.get("text") or "")
+                elif "content" in item:
+                    text_parts.append(str(item.get("content") or ""))
+            elif item is not None:
+                text_parts.append(str(item))
+        return "".join(text_parts).strip()
+    return str(content or "").strip()
+
+
 def _extract_quote(response_data: dict) -> str:
     choices = response_data.get("choices") or []
-    if not choices:
-        return DAILY_QUOTE_FALLBACK
-    message = (choices[0] or {}).get("message") or {}
-    content = (message.get("content") or "").strip()
-    return content or DAILY_QUOTE_FALLBACK
+    if choices:
+        first_choice = choices[0] or {}
+        message = first_choice.get("message") or {}
+        content = _stringify_content(message.get("content"))
+        if content:
+            return content
+
+        text = _stringify_content(first_choice.get("text"))
+        if text:
+            return text
+
+        delta = first_choice.get("delta") or {}
+        delta_content = _stringify_content(delta.get("content"))
+        if delta_content:
+            return delta_content
+
+    for key in ("output_text", "response", "result"):
+        value = response_data.get(key)
+        if isinstance(value, dict):
+            nested = _stringify_content(value.get("response") or value.get("output_text"))
+            if nested:
+                return nested
+        else:
+            direct = _stringify_content(value)
+            if direct:
+                return direct
+
+    return DAILY_QUOTE_FALLBACK
 
 
 def _call_quote_api(today: str) -> tuple[str, bool]:
@@ -63,6 +101,7 @@ def _call_quote_api(today: str) -> tuple[str, bool]:
             },
         ],
         "temperature": 0.8,
+        "stream": False,
     }
 
     req = Request(
@@ -100,11 +139,17 @@ def _check_rate_limit(client_ip: str) -> bool:
 def daily_quote():
     client_ip = request.headers.get("X-Forwarded-For", request.remote_addr or "unknown").split(",")[0].strip()
     if not _check_rate_limit(client_ip):
-        return jsonify({"quote": DAILY_QUOTE_FALLBACK, "date": _today_str(), "error": "rate_limited"}), 429
+        return jsonify({
+            "quote": DAILY_QUOTE_FALLBACK,
+            "date": _today_str(),
+            "error": "rate_limited",
+            "isFallback": True,
+        }), 429
 
     today = _today_str()
     with QUOTE_LOCK:
-        if QUOTE_CACHE["date"] != today:
+        should_refresh = QUOTE_CACHE["date"] != today or QUOTE_CACHE["is_fallback"]
+        if should_refresh:
             quote, is_fallback = _call_quote_api(today)
             QUOTE_CACHE["quote"] = quote
             QUOTE_CACHE["is_fallback"] = is_fallback

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -133,6 +133,10 @@ html, body {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(5, 13, 22, 0.55);
+  border: 1px solid rgba(160, 230, 255, 0.12);
 }
 
 .calc-screen-wrap {
@@ -145,6 +149,9 @@ html, body {
   text-align: right;
   padding: 10px;
   border-radius: 10px;
+  background: rgba(0, 0, 0, 0.36);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #eaf9ff;
 }
 
 .calc-out {
@@ -166,6 +173,7 @@ html, body {
   min-height: 44px;
   font-size: 18px;
   border-radius: 10px;
+  appearance: none;
 }
 
 .calc-key-op { color: #9ee6ff; }

--- a/static/js/tools/calculator.js
+++ b/static/js/tools/calculator.js
@@ -118,7 +118,7 @@ export async function init(){
   container.className = 'calc-widget';
   container.innerHTML = `
     <div class="calc-screen-wrap">
-      <input id="calcExpr" class="calc-screen" placeholder="0" aria-label="计算表达式" readonly />
+      <input id="calcExpr" class="calc-screen" placeholder="0" aria-label="计算表达式" inputmode="decimal" autocomplete="off" spellcheck="false" />
       <div id="calcOut" class="calc-out">点击数字和运算符开始计算</div>
     </div>
     <div class="calc-pad" role="group" aria-label="计算器按键">
@@ -152,6 +152,11 @@ export async function init(){
   const expr = container.querySelector('#calcExpr');
   const out = container.querySelector('#calcOut');
 
+
+  function normalizeExpr(value){
+    return (value || '').replace(/[^0-9+\-*/().]/g, '');
+  }
+
   function run(){
     try{
       const res = safeEvaluate(expr.value);
@@ -180,8 +185,33 @@ export async function init(){
       }
       expr.value += val;
       out.textContent = '继续输入';
+      expr.focus();
     });
   });
+
+  expr.addEventListener('input', ()=>{
+    const cleaned = normalizeExpr(expr.value);
+    if(cleaned !== expr.value) expr.value = cleaned;
+    out.textContent = expr.value ? '继续输入' : '已清空';
+  });
+
+  expr.addEventListener('keydown', (event)=>{
+    if(event.key === 'Enter'){
+      event.preventDefault();
+      run();
+      return;
+    }
+    if(event.key === 'Escape'){
+      expr.value = '';
+      out.textContent = '已清空';
+    }
+  });
+
+  container.onToolShow = ()=>{
+    expr.focus();
+    const end = expr.value.length;
+    expr.setSelectionRange(end, end);
+  };
 
   return container;
 }

--- a/static/js/tools/dailyQuote.js
+++ b/static/js/tools/dailyQuote.js
@@ -17,12 +17,17 @@ export async function init(){
     const controller = new AbortController();
     const timer = setTimeout(()=> controller.abort(), 5000);
     try {
-      const resp = await fetch('/api/daily-quote', { method: 'GET', signal: controller.signal });
+      const resp = await fetch('/api/daily-quote', {
+        method: 'GET',
+        signal: controller.signal,
+        cache: 'no-store',
+      });
       if(!resp.ok) throw new Error(`http-${resp.status}`);
       const data = await resp.json();
       textEl.textContent = data.quote || '你瞅啥';
       if(data.isFallback){
-        metaEl.textContent = data.date ? `日期：${data.date}（已启用兜底文案）` : '已启用兜底文案';
+        const reason = data.error ? `，原因：${data.error}` : '';
+        metaEl.textContent = data.date ? `日期：${data.date}（已启用兜底文案${reason}）` : `已启用兜底文案${reason}`;
       }else{
         metaEl.textContent = data.date ? `日期：${data.date}` : '';
       }

--- a/tests/test_daily_quote.py
+++ b/tests/test_daily_quote.py
@@ -1,6 +1,7 @@
+import json
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import app as board_app
 
@@ -18,14 +19,67 @@ class DailyQuoteTests(unittest.TestCase):
         self.assertEqual(quote, board_app.DAILY_QUOTE_FALLBACK)
         self.assertTrue(is_fallback)
 
+    def test_extract_quote_supports_array_content(self):
+        payload = {
+            "choices": [
+                {"message": {"content": [{"type": "text", "text": "向光而行"}]}}
+            ]
+        }
+        quote = board_app._extract_quote(payload)
+        self.assertEqual(quote, "向光而行")
+
+    def test_extract_quote_supports_choice_text(self):
+        payload = {"choices": [{"text": "山高路远，行则将至"}]}
+        quote = board_app._extract_quote(payload)
+        self.assertEqual(quote, "山高路远，行则将至")
+
+    @patch.dict(
+        os.environ,
+        {
+            "DAILY_QUOTE_API_KEY": "k",
+            "DAILY_QUOTE_API_URL": "https://example.com/v1/chat/completions",
+            "DAILY_QUOTE_MODEL": "test-model",
+        },
+        clear=True,
+    )
+    @patch("app.urlopen")
+    def test_call_quote_api_sets_stream_false(self, mocked_urlopen):
+        mocked_resp = MagicMock()
+        mocked_resp.read.return_value = json.dumps(
+            {"choices": [{"message": {"content": "愿你前路有光"}}]}
+        ).encode("utf-8")
+        mocked_urlopen.return_value.__enter__.return_value = mocked_resp
+
+        quote, is_fallback = board_app._call_quote_api("2026-03-05")
+
+        self.assertEqual(quote, "愿你前路有光")
+        self.assertFalse(is_fallback)
+        request_obj = mocked_urlopen.call_args[0][0]
+        payload = json.loads(request_obj.data.decode("utf-8"))
+        self.assertIs(payload["stream"], False)
+
+    def test_refreshes_when_cache_is_fallback(self):
+        board_app.QUOTE_CACHE["date"] = board_app._today_str()
+        board_app.QUOTE_CACHE["quote"] = board_app.DAILY_QUOTE_FALLBACK
+        board_app.QUOTE_CACHE["is_fallback"] = True
+
+        with patch("app._call_quote_api", return_value=("今天会更好", False)) as mocked:
+            resp = self.client.get("/api/daily-quote")
+
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.get_json()
+        self.assertEqual(payload["quote"], "今天会更好")
+        self.assertFalse(payload["isFallback"])
+        mocked.assert_called_once()
+
     @patch.dict(os.environ, {}, clear=True)
     def test_api_response_marks_fallback_flag(self):
-        resp = self.client.get('/api/daily-quote')
+        resp = self.client.get("/api/daily-quote")
         self.assertEqual(resp.status_code, 200)
         payload = resp.get_json()
         self.assertEqual(payload["quote"], board_app.DAILY_QUOTE_FALLBACK)
         self.assertTrue(payload["isFallback"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation

- Make the daily-quote handling robust against multiple API response shapes and ensure the site recovers from fallback quotes by re-fetching when appropriate. 
- Improve the calculator widget UI and keyboard/interaction behavior for a better user experience. 
- Surface fallback reasons to users and ensure API requests are non-streaming for compatibility.

### Description

- Added `_stringify_content` and expanded `_extract_quote` in `app.py` to handle `choices[].message.content` arrays, `choices[].text`, `choices[].delta`, and several nested response fields before falling back to `DAILY_QUOTE_FALLBACK`. 
- Set the outgoing payload `"stream": False` in `_call_quote_api` and made the server refresh the cached quote when the cache is a fallback by checking `QUOTE_CACHE["is_fallback"]`. 
- Included `isFallback` and error reason metadata in the 429 rate-limited JSON response and in normal responses. 
- Updated CSS in `static/css/style.css` to restyle the calculator (`.calc-widget`, `.calc-screen`, and keys) with padding, rounded corners, background, and appearances. 
- Enhanced calculator JS in `static/js/tools/calculator.js` to allow editable input (`inputmode`, `autocomplete`, `spellcheck`), sanitize input with `normalizeExpr`, add keyboard handlers (Enter/Escape), focus behavior on show, and minor UX messages. 
- Adjusted `static/js/tools/dailyQuote.js` to disable fetch caching (`cache: 'no-store'`) and to display fallback reasons from the API. 
- Added and extended unit tests in `tests/test_daily_quote.py` to cover array `content` parsing, `choices[].text`, ensuring `stream` is set to `False` in requests, and refreshing when cache is marked as a fallback.

### Testing

- Ran the updated unit tests in `tests/test_daily_quote.py` with `python -m unittest tests.test_daily_quote` and all tests passed. 
- Exercised the quote parsing code paths via mocked `urlopen` and environment variables in the unit tests which validated the new parsing rules and `stream` payload flag. 
- Verified the cache-refresh behavior via a unit test that patches `_call_quote_api` and asserts the API is invoked when `QUOTE_CACHE["is_fallback"]` is true.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8e34ff6648322993606ba9880368a)