### PR TITLE
Expose daily-quote backend debug info and surface diagnostics in the widget

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ QUOTE_CACHE = {
     "date": None,
     "quote": DAILY_QUOTE_FALLBACK,
     "is_fallback": True,
+    "debug": {},
 }
 QUOTE_LOCK = threading.Lock()
 
@@ -83,13 +84,33 @@ def _extract_quote(response_data: dict) -> str:
     return DAILY_QUOTE_FALLBACK
 
 
-def _call_quote_api(today: str) -> tuple[str, bool]:
+def _truncate_text(value: object, limit: int = 800) -> str:
+    text = _stringify_content(value)
+    if len(text) <= limit:
+        return text
+    return text[:limit].strip() + "…"
+
+
+def _call_quote_api(today: str) -> tuple[str, bool, dict]:
     api_key = os.environ.get("DAILY_QUOTE_API_KEY", "")
     api_url = os.environ.get("DAILY_QUOTE_API_URL", "")
     model_name = os.environ.get("DAILY_QUOTE_MODEL", "")
 
     if not api_key or not api_url or not model_name:
-        return DAILY_QUOTE_FALLBACK, True
+        missing = [
+            name
+            for name, value in (
+                ("DAILY_QUOTE_API_KEY", api_key),
+                ("DAILY_QUOTE_API_URL", api_url),
+                ("DAILY_QUOTE_MODEL", model_name),
+            )
+            if not value
+        ]
+        return DAILY_QUOTE_FALLBACK, True, {
+            "stage": "config",
+            "error": "missing_env",
+            "missing": missing,
+        }
 
     payload = {
         "model": model_name,
@@ -116,11 +137,46 @@ def _call_quote_api(today: str) -> tuple[str, bool]:
 
     try:
         with urlopen(req, timeout=8) as resp:
-            data = json.loads(resp.read().decode("utf-8"))
+            status_code = getattr(resp, "status", None)
+            raw_text = resp.read().decode("utf-8", errors="replace")
+            data = json.loads(raw_text)
             quote = _extract_quote(data)
-            return quote, quote == DAILY_QUOTE_FALLBACK
-    except (URLError, HTTPError, TimeoutError, json.JSONDecodeError):
-        return DAILY_QUOTE_FALLBACK, True
+            is_fallback = quote == DAILY_QUOTE_FALLBACK
+            debug = {
+                "stage": "response",
+                "status": status_code,
+                "is_json": True,
+                "excerpt": _truncate_text(raw_text),
+            }
+            if is_fallback:
+                debug["error"] = "empty_quote"
+            return quote, is_fallback, debug
+    except HTTPError as err:
+        err_body = err.read().decode("utf-8", errors="replace")
+        return DAILY_QUOTE_FALLBACK, True, {
+            "stage": "request",
+            "error": "http_error",
+            "status": err.code,
+            "excerpt": _truncate_text(err_body),
+        }
+    except json.JSONDecodeError as err:
+        return DAILY_QUOTE_FALLBACK, True, {
+            "stage": "response",
+            "error": "invalid_json",
+            "status": 200,
+            "detail": str(err),
+        }
+    except TimeoutError:
+        return DAILY_QUOTE_FALLBACK, True, {
+            "stage": "request",
+            "error": "timeout",
+        }
+    except URLError as err:
+        return DAILY_QUOTE_FALLBACK, True, {
+            "stage": "request",
+            "error": "url_error",
+            "detail": str(err.reason),
+        }
 
 
 def _check_rate_limit(client_ip: str) -> bool:
@@ -144,21 +200,28 @@ def daily_quote():
             "date": _today_str(),
             "error": "rate_limited",
             "isFallback": True,
+            "debug": {
+                "stage": "gateway",
+                "error": "rate_limited",
+                "status": 429,
+            },
         }), 429
 
     today = _today_str()
     with QUOTE_LOCK:
         should_refresh = QUOTE_CACHE["date"] != today or QUOTE_CACHE["is_fallback"]
         if should_refresh:
-            quote, is_fallback = _call_quote_api(today)
+            quote, is_fallback, debug = _call_quote_api(today)
             QUOTE_CACHE["quote"] = quote
             QUOTE_CACHE["is_fallback"] = is_fallback
             QUOTE_CACHE["date"] = today
+            QUOTE_CACHE["debug"] = debug
 
         quote = QUOTE_CACHE["quote"] or DAILY_QUOTE_FALLBACK
         is_fallback = QUOTE_CACHE["is_fallback"]
+        debug = QUOTE_CACHE.get("debug") or {}
 
-    return jsonify({"quote": quote, "date": today, "isFallback": is_fallback})
+    return jsonify({"quote": quote, "date": today, "isFallback": is_fallback, "debug": debug})
 
 
 if __name__ == "__main__":

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -223,3 +223,30 @@ html, body {
   font-size: 13px;
   color: var(--muted);
 }
+
+.quote-debug {
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.28);
+  padding: 8px 10px;
+}
+
+.quote-debug summary {
+  cursor: pointer;
+  color: #9ee6ff;
+  font-size: 13px;
+  user-select: none;
+}
+
+.quote-debug pre {
+  margin: 8px 0 0;
+  max-height: 180px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #d8f3ff;
+}

--- a/static/js/tools/dailyQuote.js
+++ b/static/js/tools/dailyQuote.js
@@ -5,15 +5,32 @@ export async function init(){
     <div class="quote-title">每日名言</div>
     <div id="quoteText" class="quote-text">加载中...</div>
     <div id="quoteMeta" class="quote-meta"></div>
+    <details id="quoteDebug" class="quote-debug" hidden>
+      <summary>查看异常详情</summary>
+      <pre id="quoteDebugContent"></pre>
+    </details>
     <button id="quoteRefresh" class="quote-refresh">手动刷新</button>
   `;
 
   const textEl = el.querySelector('#quoteText');
   const metaEl = el.querySelector('#quoteMeta');
+  const debugEl = el.querySelector('#quoteDebug');
+  const debugContentEl = el.querySelector('#quoteDebugContent');
+
+  function renderDebug(debug){
+    if(!debug || Object.keys(debug).length === 0){
+      debugEl.hidden = true;
+      debugContentEl.textContent = '';
+      return;
+    }
+    debugEl.hidden = false;
+    debugContentEl.textContent = JSON.stringify(debug, null, 2);
+  }
 
   async function loadQuote(){
     textEl.textContent = '加载中...';
     metaEl.textContent = '';
+    renderDebug(null);
     const controller = new AbortController();
     const timer = setTimeout(()=> controller.abort(), 5000);
     try {
@@ -22,18 +39,28 @@ export async function init(){
         signal: controller.signal,
         cache: 'no-store',
       });
-      if(!resp.ok) throw new Error(`http-${resp.status}`);
-      const data = await resp.json();
+      const data = await resp.json().catch(()=> ({}));
+      if(!resp.ok){
+        const error = new Error(`http-${resp.status}`);
+        error.payload = data;
+        throw error;
+      }
       textEl.textContent = data.quote || '你瞅啥';
       if(data.isFallback){
-        const reason = data.error ? `，原因：${data.error}` : '';
+        const reason = data.debug?.error ? `，原因：${data.debug.error}` : '';
         metaEl.textContent = data.date ? `日期：${data.date}（已启用兜底文案${reason}）` : `已启用兜底文案${reason}`;
+        renderDebug(data.debug);
       }else{
         metaEl.textContent = data.date ? `日期：${data.date}` : '';
+        renderDebug(null);
       }
-    } catch {
+    } catch (err) {
       textEl.textContent = '你瞅啥';
-      metaEl.textContent = '已启用兜底文案';
+      metaEl.textContent = '请求失败，已启用兜底文案';
+      renderDebug({
+        error: err?.message || 'request_failed',
+        payload: err?.payload || null,
+      });
     } finally {
       clearTimeout(timer);
     }


### PR DESCRIPTION
### Motivation
- Make it possible to see why the daily-quote tool falls back to a default by surfacing upstream/API errors and other failure context instead of silently swallowing them. 
- Help diagnose cases where manual refresh doesn’t change behavior by returning structured `debug` info from the backend and showing it in the UI. 
- Preserve a clean UI while providing an expandable diagnostics panel for developers/operators to inspect error details.

### Description
- Backend: add `debug` to `QUOTE_CACHE` and extend `_call_quote_api` to return `(quote, is_fallback, debug)` with structured info for config problems, HTTP errors, timeouts, URL errors, invalid JSON and empty content, plus a `_truncate_text` helper for long excerpts. 
- API: include the `debug` object in `/api/daily-quote` responses and return rate-limit debug metadata for 429 responses. 
- Frontend: update `static/js/tools/dailyQuote.js` to add an expandable `details` panel that displays the backend `debug` JSON, improve fallback messaging, and surface response payloads on error. 
- Styling: add `.quote-debug` rules in `static/css/style.css` to keep the diagnostics panel visually consistent and scrollable for long output. 

### Testing
- Ran `python -m py_compile app.py` which succeeded. 
- Started the server and verified the endpoint with `curl -s http://127.0.0.1:5000/api/daily-quote` which returned JSON including the new `debug` object (example showed missing env vars). 
- Attempted an automated browser screenshot run via Playwright but Chromium failed to start in the environment (SIGSEGV), so UI screenshot validation was not produced; server-side and curl validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8f2712ce08322b3beb1d0c017f19b)