### PR TITLE
Add NTP-based time-sync endpoint and client-side time offset synchronization

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import json
 import os
+import socket
 import threading
 import time
 from collections import defaultdict, deque
@@ -20,6 +21,10 @@ QUOTE_CACHE = {
     "debug": {},
 }
 QUOTE_LOCK = threading.Lock()
+
+NTP_SERVER = os.environ.get("NTP_SERVER", "ntp.aliyun.com")
+NTP_PORT = int(os.environ.get("NTP_PORT", "123"))
+NTP_TIMEOUT_SEC = float(os.environ.get("NTP_TIMEOUT_SEC", "2.5"))
 
 RATE_LIMIT_WINDOW = 60
 RATE_LIMIT_MAX = 30
@@ -225,6 +230,59 @@ def daily_quote():
         debug = QUOTE_CACHE.get("debug") or {}
 
     return jsonify({"quote": quote, "date": today, "isFallback": is_fallback, "debug": debug})
+
+
+@app.route("/api/time-sync", methods=["GET"])
+def time_sync():
+    timezone = (request.args.get("tz") or "Etc/UTC").strip()
+    try:
+        ZoneInfo(timezone)
+    except Exception:
+        return jsonify({"error": "invalid_timezone", "timezone": timezone}), 400
+
+    # NTP 授时规则：
+    # - 使用 UDP 123 端口发送 48 字节请求包，首字节设置为 0x1B（LI=0,VN=3,Mode=3 client）
+    # - 服务端回包中的 transmit timestamp（字节 40-47）是自 1900-01-01 起的时间戳
+    # - 需减去 NTP 与 Unix 纪元偏移量 2208988800 秒
+    local_utc_ms = int(time.time() * 1000)
+    ntp_epoch_offset = 2208988800
+    try:
+        packet = b"\x1b" + 47 * b"\0"
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.settimeout(NTP_TIMEOUT_SEC)
+            s.sendto(packet, (NTP_SERVER, NTP_PORT))
+            data, _ = s.recvfrom(48)
+
+        if len(data) < 48:
+            raise ValueError("invalid_ntp_packet")
+
+        seconds = int.from_bytes(data[40:44], "big")
+        fraction = int.from_bytes(data[44:48], "big")
+        unix_seconds = seconds - ntp_epoch_offset
+        remote_utc_ms = int(unix_seconds * 1000 + (fraction * 1000 / 2**32))
+
+        return jsonify(
+            {
+                "serverTimeMs": remote_utc_ms,
+                "localTimeMs": local_utc_ms,
+                "offsetMs": remote_utc_ms - local_utc_ms,
+                "timezone": timezone,
+                "source": f"ntp://{NTP_SERVER}:{NTP_PORT}",
+                "isFallback": False,
+            }
+        )
+    except (socket.timeout, OSError, ValueError):
+        # 公共授时源不可用时自动回退到本地时间，保证页面仍可运行。
+        return jsonify(
+            {
+                "serverTimeMs": local_utc_ms,
+                "localTimeMs": local_utc_ms,
+                "offsetMs": 0,
+                "timezone": timezone,
+                "source": "local-fallback",
+                "isFallback": True,
+            }
+        )
 
 
 if __name__ == "__main__":

--- a/static/js/clock.js
+++ b/static/js/clock.js
@@ -1,4 +1,6 @@
-document.addEventListener('DOMContentLoaded', ()=>{
+import { getSyncedNow, loadTimeOffset } from './timeSync.js';
+
+document.addEventListener('DOMContentLoaded', async ()=>{
   const svgNS = "http://www.w3.org/2000/svg";
   const marksGroup = document.getElementById('marks');
   const hourHand = document.getElementById('hourHand');
@@ -49,9 +51,10 @@ document.addEventListener('DOMContentLoaded', ()=>{
   }
 
   ensureMarks();
+  await loadTimeOffset();
 
   function updateSVGClock(){
-    const now = new Date();
+    const now = getSyncedNow();
     const ms = now.getMilliseconds();
     const s = now.getSeconds() + ms/1000;
     const m = now.getMinutes() + s/60;

--- a/static/js/timeSync.js
+++ b/static/js/timeSync.js
@@ -1,0 +1,36 @@
+let cachedOffsetMs = 0;
+let syncLoaded = false;
+let cachedTimezone = 'Etc/UTC';
+
+function getDeviceTimezone(){
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return tz && typeof tz === 'string' ? tz : 'Etc/UTC';
+}
+
+export async function loadTimeOffset(){
+  const timezone = getDeviceTimezone();
+  if(syncLoaded && timezone === cachedTimezone){
+    return cachedOffsetMs;
+  }
+
+  cachedTimezone = timezone;
+
+  try{
+    const params = new URLSearchParams({ tz: timezone });
+    const resp = await fetch(`/api/time-sync?${params.toString()}`, { cache: 'no-store' });
+    if(!resp.ok){
+      throw new Error(`time-sync-http-${resp.status}`);
+    }
+    const data = await resp.json();
+    cachedOffsetMs = Number.isFinite(data.offsetMs) ? data.offsetMs : 0;
+  }catch(_err){
+    cachedOffsetMs = 0;
+  }
+
+  syncLoaded = true;
+  return cachedOffsetMs;
+}
+
+export function getSyncedNow(){
+  return new Date(Date.now() + cachedOffsetMs);
+}

--- a/static/js/tools/worldClocks.js
+++ b/static/js/tools/worldClocks.js
@@ -1,3 +1,5 @@
+import { getSyncedNow, loadTimeOffset } from '../timeSync.js';
+
 export async function init(){
   const el = document.createElement('div');
   const zones = [
@@ -13,7 +15,7 @@ export async function init(){
 
   function render(){
     list.innerHTML = '';
-    const now = new Date();
+    const now = getSyncedNow();
     zones.forEach(z=>{
       const dstr = now.toLocaleString('zh-Hans-CN', { timeZone: z.id });
       const row = document.createElement('div');
@@ -38,6 +40,7 @@ export async function init(){
   el.onToolShow = start;
   el.onToolHide = stop;
 
+  await loadTimeOffset();
   // 首次加载立即显示
   start();
   return el;


### PR DESCRIPTION
### Motivation
- Provide a reliable clock on the UI by synchronizing client time with a server NTP source and falling back to local time when unreachable.
- Reduce visible clock drift across clients in different timezones and improve world clock accuracy.
- Make NTP server, port and timeout configurable via environment variables for deployment flexibility.

### Description
- Add `/api/time-sync` endpoint in `app.py` that queries an NTP server over UDP (port 123) and returns `serverTimeMs`, `localTimeMs`, `offsetMs`, `timezone`, `source`, and `isFallback`, with a local fallback when NTP fails; new env vars `NTP_SERVER`, `NTP_PORT`, and `NTP_TIMEOUT_SEC` control behavior.
- Introduce `static/js/timeSync.js` which fetches `/api/time-sync`, caches the offset and timezone, and exposes `loadTimeOffset()` and `getSyncedNow()` for client code.
- Update `static/js/clock.js` and `static/js/tools/worldClocks.js` to await `loadTimeOffset()` on load and use `getSyncedNow()` so the visible clock and world clocks use the synchronized time.
- Preserve graceful degradation: if the NTP query or client fetch fails, code falls back to local system time with `isFallback` set accordingly.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa7dbf931c8322a628adeedec1a633)